### PR TITLE
Update minato-aqua.ts

### DIFF
--- a/src/dictionary/hololive/jp/gen2/minato-aqua.ts
+++ b/src/dictionary/hololive/jp/gen2/minato-aqua.ts
@@ -14,4 +14,7 @@ export const minatoAqua: LiverData = {
   fans: ['あくあクルー'],
   twitter: ['@minatoaqua'],
   others: [['あくきん', 'AKUKIN']],
+  flags: {
+    isActive: false,
+  },
 };


### PR DESCRIPTION
湊あくあは 2024-08-28 に卒業しました（[「湊あくあ」卒業に関するお知らせ | カバー株式会社](https://cover-corp.com/news/detail/20240806-01)）。